### PR TITLE
Change k8s API links from v1.14 to v1.19

### DIFF
--- a/docs/objects/configmap/index.html
+++ b/docs/objects/configmap/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#configmap-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#configmap-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/container/index.html
+++ b/docs/objects/container/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#container-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/cronjob/index.html
+++ b/docs/objects/cronjob/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#cronjob-v1-batch">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#cronjob-v1-batch">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/daemonset/index.html
+++ b/docs/objects/daemonset/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#daemonset-v1-apps">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#daemonset-v1-apps">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/deployment/index.html
+++ b/docs/objects/deployment/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deployment-v1-apps">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#deployment-v1-apps">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/endpoints/index.html
+++ b/docs/objects/endpoints/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#endpoints-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#endpoints-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/ingress/index.html
+++ b/docs/objects/ingress/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#ingress-v1beta1-extensions">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingress-v1beta1-extensions">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/job/index.html
+++ b/docs/objects/job/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#job-v1-batch">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#job-v1-batch">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/persistentvolume/index.html
+++ b/docs/objects/persistentvolume/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#persistentvolume-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolume-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/persistentvolumeclaim/index.html
+++ b/docs/objects/persistentvolumeclaim/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#persistentvolumeclaim-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#persistentvolumeclaim-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/pod/index.html
+++ b/docs/objects/pod/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#pod-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pod-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/replicaset/index.html
+++ b/docs/objects/replicaset/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#replicaset-v1-apps">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#replicaset-v1-apps">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/replicationcontroller/index.html
+++ b/docs/objects/replicationcontroller/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#replicationcontroller-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#replicationcontroller-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/secret/index.html
+++ b/docs/objects/secret/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#secret-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#secret-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/service/index.html
+++ b/docs/objects/service/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#service-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#service-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/statefulset/index.html
+++ b/docs/objects/statefulset/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#statefulset-v1-apps">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#statefulset-v1-apps">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/storageclass/index.html
+++ b/docs/objects/storageclass/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#storageclass-v1-storage-k8s-io">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#storageclass-v1-storage-k8s-io">
     <span class="label focus">
       API reference
     </span>

--- a/docs/objects/volume/index.html
+++ b/docs/objects/volume/index.html
@@ -109,7 +109,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#volume-v1-core">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#volume-v1-core">
     <span class="label focus">
       API reference
     </span>

--- a/layouts/objects/single.html
+++ b/layouts/objects/single.html
@@ -15,7 +15,7 @@
 
 
 
-  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#{{ .Params.doclink }}">
+  <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{ .Params.doclink }}">
     <span class="label focus">
       API reference
     </span>


### PR DESCRIPTION
 - Due to 404 error on v1.14 links